### PR TITLE
Update aiohttp-jinja2 to Version 1.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "aiohttp-jinja2" %}
-{% set version = "1.4.2" %}
+{% set version = "1.5" %}
 
 package:
   name: "{{ name|lower }}"
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 9c22a0e48e3b277fc145c67dd8c3b8f609dab36bce9eb337f70dfe716663c9a0
+  sha256: 7c3ba5eac060b691f4e50534af2d79fca2a75712ebd2b25e6fcb1295859f910b
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,6 @@ source:
 build:
   number: 0
   noarch: python
-  skip: True  # [py<36]
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv "
 
 requirements:
@@ -32,7 +31,7 @@ test:
     - aiohttp_jinja2
   requires:
     - pip
-    - python <3.10
+    - python
   commands:
     - pip check
 
@@ -43,7 +42,7 @@ about:
   license_file: LICENSE
   summary: jinja2 template renderer for aiohttp.web (http server for asyncio)
   dev_url: https://github.com/aio-libs/aiohttp-jinja2/
-  doc_url: http://aiohttp-jinja2.readthedocs.org/
+  doc_url: https://aiohttp-jinja2.readthedocs.org/
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,6 +41,7 @@ about:
   license_family: APACHE
   license_file: LICENSE
   summary: jinja2 template renderer for aiohttp.web (http server for asyncio)
+  dev_url: https://github.com/aio-libs/aiohttp-jinja2/
   doc_url: http://aiohttp-jinja2.readthedocs.org/
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,7 @@ test:
     - pip
     - python <3.10
   commands:
-    -pip check
+    - pip check
 
 about:
   home: https://github.com/aio-libs/aiohttp-jinja2/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,7 @@ source:
 build:
   number: 0
   noarch: python
+  skip: True  # [py<35]
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv "
 
 requirements:
@@ -19,7 +20,7 @@ requirements:
     - aiohttp >=3.2.0
     - jinja2 >=2.10.1
     - pip
-    - python >3.5.3
+    - python
   run:
     - aiohttp >=3.2.0
     - jinja2 >=2.10.1
@@ -28,6 +29,11 @@ requirements:
 test:
   imports:
     - aiohttp_jinja2
+  requires:
+    - pip
+    - python <3.10
+  commands:
+    -pip check
 
 about:
   home: https://github.com/aio-libs/aiohttp-jinja2/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,19 +12,20 @@ source:
 build:
   number: 0
   noarch: python
-  skip: True  # [py<35]
+  skip: True  # [py<36]
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv "
 
 requirements:
   host:
-    - aiohttp >=3.2.0
-    - jinja2 >=2.10.1
     - pip
     - python
+    - setuptools
+    - wheel
   run:
-    - aiohttp >=3.2.0
-    - jinja2 >=2.10.1
-    - python >3.5.3
+    - aiohttp >=3.6.3
+    - jinja2 >=3.0.0
+    - python >3.5
+    - typing_extensions>=3.7.4  # [py<38]
 
 test:
   imports:
@@ -37,7 +38,7 @@ test:
 
 about:
   home: https://github.com/aio-libs/aiohttp-jinja2/
-  license: Apache Software
+  license: Apache-2.0
   license_family: APACHE
   license_file: LICENSE
   summary: jinja2 template renderer for aiohttp.web (http server for asyncio)


### PR DESCRIPTION
1. check the upstream

2. check the pinnings
https://github.com/aio-libs/aiohttp-jinja2/blob/master/setup.py
https://github.com/aio-libs/aiohttp-jinja2/blob/master/setup.cfg

    - aiohttp >=3.2.0
    https://github.com/aio-libs/aiohttp-jinja2/blob/master/setup.py#L33
    change aiohttp pinnings to version 3.6.2

    - jinja2 >=2.10.1
    https://github.com/aio-libs/aiohttp-jinja2/blob/master/setup.py#L34

    https://github.com/aio-libs/aiohttp-jinja2/blob/master/setup.py#L65
    change python pinnings 

3. check changelogs
https://github.com/aio-libs/aiohttp-jinja2/blob/master/CHANGES.rst

drop support for `jinja2` <3 
the package no longer requires `typing_extensions` 

4. additional research
https://github.com/conda-forge/aiohttp-jinja2-feedstock/issues

There are no open issues mentioned in conda-forge at the time of the review

5. verify dev_url
    https://github.com/aio-libs/aiohttp-jinja2/

6. verify doc_url
    http://aiohttp-jinja2.readthedocs.org/

7. added pip to the test section
8. verify the test section
9. additional tests

In order to test the `aiohttp-jinja2` package version `1.5` the following command was used:
`conda build aiohttp-jinja2-feedstock --test` 
The test result was the following:
`All tests passed`

Based on the research findings and on the test results we can conclude that it is safe to update `aiohttp-jinja2` to version `1.5`
