### PR TITLE
aiohttp-jinja2 1.6

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,18 +1,18 @@
 {% set name = "aiohttp-jinja2" %}
-{% set version = "1.5" %}
+{% set version = "1.6" %}
 
 package:
-  name: "{{ name|lower }}"
-  version: "{{ version }}"
+  name: {{ name|lower }}
+  version: {{ version }}
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 7c3ba5eac060b691f4e50534af2d79fca2a75712ebd2b25e6fcb1295859f910b
+  sha256: a3a7ff5264e5bca52e8ae547bbfd0761b72495230d438d05b6c0915be619b0e2
 
 build:
   number: 0
-  noarch: python
-  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv "
+  skip: true  # [py<38]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
 requirements:
   host:
@@ -21,17 +21,14 @@ requirements:
     - setuptools
     - wheel
   run:
-    - aiohttp >=3.6.3
+    - python
+    - aiohttp >=3.9.0
     - jinja2 >=3.0.0
-    - python >3.5
-    - typing_extensions>=3.7.4  # [py<38]
-
 test:
   imports:
     - aiohttp_jinja2
   requires:
     - pip
-    - python
   commands:
     - pip check
 
@@ -41,8 +38,9 @@ about:
   license_family: APACHE
   license_file: LICENSE
   summary: jinja2 template renderer for aiohttp.web (http server for asyncio)
+  description: jinja2 template renderer for aiohttp.web (http server for asyncio)
   dev_url: https://github.com/aio-libs/aiohttp-jinja2/
-  doc_url: https://aiohttp-jinja2.readthedocs.org/
+  doc_url: https://aiohttp-jinja2.readthedocs.io/
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-5315](https://anaconda.atlassian.net/browse/PKG-5315) 
- [Upstream repository](https://github.com/aio-libs/aiohttp-jinja2/tree/v1.6)
- Requirements: https://github.com/aio-libs/aiohttp-jinja2/blob/v1.6/setup.py

### Explanation of changes:

- Apply conda-linter --fix to clean up the recipe
- Update runtime dependencies and pinnings
- Remove redundant python from test/requires
- Add description
- Update doc_url because of a redirection

### Notes:

-

[PKG-5315]: https://anaconda.atlassian.net/browse/PKG-5315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ